### PR TITLE
feat: add standard pagination response for meta field in MedarisResponse

### DIFF
--- a/libs/common/src/response/index.ts
+++ b/libs/common/src/response/index.ts
@@ -1,1 +1,3 @@
 export * from './medaris.response';
+export { MedarisMetaResponse } from './medaris-meta.response'
+export { MedarisMetaPaginationResponse } from './medaris-meta-pagination.response'

--- a/libs/common/src/response/medaris-meta-pagination.response.ts
+++ b/libs/common/src/response/medaris-meta-pagination.response.ts
@@ -3,7 +3,7 @@ import { ApiProperty, ApiSchema } from "@nestjs/swagger";
 @ApiSchema({
   description: 'Pagination metadata returned under the meta.pagination field in paginated API responses.'
 })
-export class MetaPaginationResponse {
+export class MedarisMetaPaginationResponse {
     @ApiProperty({
         minimum: 0,
         description: 'Number of items on the current page'

--- a/libs/common/src/response/medaris-meta-pagination.response.ts
+++ b/libs/common/src/response/medaris-meta-pagination.response.ts
@@ -1,0 +1,36 @@
+import { ApiProperty, ApiSchema } from "@nestjs/swagger";
+
+@ApiSchema({
+  description: 'Pagination metadata returned under the meta.pagination field in paginated API responses.'
+})
+export class MetaPaginationResponse {
+    @ApiProperty({
+        minimum: 0,
+        description: 'Number of items on the current page'
+    })
+    itemCount!: number
+
+    @ApiProperty({
+        minimum: 1,
+        description: 'Current page number (starting from 1)'
+    })
+    currentPage!: number
+
+    @ApiProperty({
+        minimum: 0,
+        description: 'Total number of available items'
+    })
+    totalItems!: number
+
+    @ApiProperty({
+        minimum: 0,
+        description: 'Maximum number of items per page'
+    })
+    itemsPerPage!: number
+
+    @ApiProperty({
+        minimum: 0,
+        description: 'Total number of pages available'
+    })
+    totalPages!: number
+}

--- a/libs/common/src/response/medaris-meta.response.ts
+++ b/libs/common/src/response/medaris-meta.response.ts
@@ -1,0 +1,9 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { MedarisMetaPaginationResponse } from "./medaris-meta-pagination.response";
+
+export class MedarisMetaResponse {
+    @ApiPropertyOptional()
+    pagination?: MedarisMetaPaginationResponse
+
+    [key: string]: unknown
+}

--- a/libs/common/src/response/medaris.response.ts
+++ b/libs/common/src/response/medaris.response.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { MedarisMetaResponse } from './medaris-meta.response';
 
 export class MedarisResponse<T = unknown> {
   @ApiProperty({
@@ -24,13 +25,13 @@ export class MedarisResponse<T = unknown> {
     required: false,
     example: { timestamp: '2024-01-15T10:30:00.000Z', version: '1.0.0' },
   })
-  meta?: Record<string, unknown>;
+  meta?: MedarisMetaResponse;
 
   constructor(
     success: boolean,
     message?: string,
     data?: T,
-    meta?: Record<string, unknown>,
+    meta?: MedarisMetaResponse,
   ) {
     this.success = success;
     this.message = message;
@@ -41,14 +42,14 @@ export class MedarisResponse<T = unknown> {
   static success<T>(
     data: T,
     message?: string,
-    meta?: Record<string, unknown>,
+    meta?: MedarisMetaResponse,
   ): MedarisResponse<T> {
     return new MedarisResponse<T>(true, message, data, meta);
   }
 
   static error(
     message: string,
-    meta?: Record<string, unknown>,
+    meta?: MedarisMetaResponse,
   ): MedarisResponse<null> {
     return new MedarisResponse<null>(false, message, null, meta);
   }


### PR DESCRIPTION
## Teamhub Task Link
NULL

## Description
Added a standardized API response class with Swagger support to represent pagination metadata for paginated requests.

```typescript
class MetaPaginationResponse {
    itemCount!: number
    currentPage!: number
    totalItems!: number
    itemsPerPage!: number
    totalPages!: number
}
```

This DTO is expected to be used under the `pagination` field inside the meta object, for example:
```typescript
medarisResponse = {
  success: true,
  meta: {
    pagination: MetaPaginationResponse,
    // other meta fields
  },
  // other response fields
}
```

The initial use case for this response was listing public decks in the flashcard module. However, I recommend including this DTO as part of the shared library to standardize pagination metadata across multiple modules.