### PR TITLE
fix(migrations): correct migration env variable to enable auto migrations

### DIFF
--- a/apps/tedrisat/src/config/config.ts
+++ b/apps/tedrisat/src/config/config.ts
@@ -36,7 +36,7 @@ export default () => ({
     endpoint: process.env.SWAGGER_PATH || '/docs',
   },
   autoMigrations: {
-    enabled: process.env.AUTO_MIGRATIONS === 'true' || false,
+    enabled: process.env.AUTO_MIGRATIONS_ENABLED === 'true' || false,
     migrationsFolder:
       process.env.AUTO_MIGRATIONS_FOLDER || './src/database/migrations',
   },


### PR DESCRIPTION
There was a naming inconsistency between .env.example and config for enabling auto migrations. 

## Teamhub Task Linki
- 

## Açıklama
I updated config to use env variable as named in .env.example
